### PR TITLE
Fixed errors in rawwebsocket transport

### DIFF
--- a/sockjs/route.py
+++ b/sockjs/route.py
@@ -152,8 +152,8 @@ class SockJSRoute:
         session = self.manager.get(sid, True, request=request)
 
         # websocket
-        if hdrs.ORIGIN in request.headers:
-            return web.HTTPNotFound()
+        # if hdrs.ORIGIN in request.headers:
+        #     return web.HTTPNotFound()
 
         transport = RawWebSocketTransport(self.manager, session, request)
         try:

--- a/sockjs/transports/rawwebsocket.py
+++ b/sockjs/transports/rawwebsocket.py
@@ -4,7 +4,8 @@ from aiohttp import web
 
 from .base import Transport
 from ..exceptions import SessionIsClosed
-from ..protocol import FRAME_CLOSE, FRAME_MESSAGE, FRAME_MESSAGE_BLOB
+from ..protocol import FRAME_CLOSE, FRAME_MESSAGE, FRAME_MESSAGE_BLOB, \
+    FRAME_HEARTBEAT
 
 
 class RawWebSocketTransport(Transport):
@@ -25,6 +26,8 @@ class RawWebSocketTransport(Transport):
                 if data.startswith('['):
                     data = data[1:-1]
                 ws.send_str(data)
+            elif frame == FRAME_HEARTBEAT:
+                ws.ping()
             elif frame == FRAME_CLOSE:
                 try:
                     yield from ws.close(message='Go away!')

--- a/sockjs/transports/rawwebsocket.py
+++ b/sockjs/transports/rawwebsocket.py
@@ -4,7 +4,7 @@ from aiohttp import web
 
 from .base import Transport
 from ..exceptions import SessionIsClosed
-from ..protocol import FRAME_CLOSE, FRAME_MESSAGE
+from ..protocol import FRAME_CLOSE, FRAME_MESSAGE, FRAME_MESSAGE_BLOB
 
 
 class RawWebSocketTransport(Transport):
@@ -20,6 +20,11 @@ class RawWebSocketTransport(Transport):
             if frame == FRAME_MESSAGE:
                 for text in data:
                     ws.send_str(text)
+            elif frame == FRAME_MESSAGE_BLOB:
+                data = data[1:]
+                if data.startswith('['):
+                    data = data[1:-1]
+                ws.send_str(data)
             elif frame == FRAME_CLOSE:
                 try:
                     yield from ws.close(message='Go away!')


### PR DESCRIPTION
1. Removed existence check for "ORIGIN" header (why it is forbidden?)
2. Process FRAME_MESSAGE_BLOB message type