### PR TITLE
fix(exmaples/chat.py): add_endpoint require name arg

### DIFF
--- a/examples/chat.py
+++ b/examples/chat.py
@@ -30,7 +30,7 @@ if __name__ == '__main__':
 
     app = web.Application(loop=loop)
     app.router.add_route('GET', '/', index)
-    sockjs.add_endpoint(app, chatSession, prefix='/sockjs/')
+    sockjs.add_endpoint(app, chatSession, name='chat', prefix='/sockjs/')
 
     handler = app.make_handler()
     srv = loop.run_until_complete(


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "C:/Users/pahaz_000/PycharmProjects/sudy/tt.py", line 34, in <module>
    sockjs.add_endpoint(app, chatSession, prefix='/sockjs/')
  File "C:\Users\pahaz_000\AppData\Local\Programs\Python\Python35-32\lib\site-packages\sockjs\route.py", line 59, in add_endpoint
    hdrs.METH_GET, prefix, route.greeting, name=route_name)
  File "C:\Users\pahaz_000\AppData\Local\Programs\Python\Python35-32\lib\site-packages\aiohttp\web_urldispatcher.py", line 481, in add_route
    self.register_route(route)
  File "C:\Users\pahaz_000\AppData\Local\Programs\Python\Python35-32\lib\site-packages\aiohttp\web_urldispatcher.py", line 455, in register_route
    'by dash, dot or column'.format(name))
ValueError: Incorrect route name 'sockjs-url--greeting', the name should be a sequence of python identifiers separated by dash, dot or column
2015-12-08 00:47:32,930 DEBUG Close <_WindowsSelectorEventLoop running=False closed=False debug=True>
2015-12-08 00:47:32,934 ERROR <CoroWrapper SessionManager.clear() running at C:\Users\pahaz_000\AppData\Local\Programs\Python\Python35-32\lib\site-packages\sockjs\session.py:388, created at C:\Users\pahaz_000\AppData\Local\Programs\Python\Python35-32\lib\site-packages\sockjs\session.py:406> was never yielded from
Coroutine object created at (most recent call last):
  File "C:\Users\pahaz_000\AppData\Local\Programs\Python\Python35-32\lib\site-packages\sockjs\session.py", line 406, in __del__
    self.clear()

```