### PR TITLE
sockjs 0.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,5 +16,5 @@ script:
   - coverage run --source=sockjs setup.py test
   - coverage report
   - python setup.py check -rm
-  - pip uninstall aiohttp -y && pip install aiohttp
-  - python setup.py test
+  - pip uninstall aiohttp -y && pip install aiohttp && python setup.py test
+  - pip uninstall aiohttp -y && pip install aiohttp==0.18.3 && python setup.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ install:
 script:
   - flake8 sockjs
   - coverage run --source=sockjs setup.py test
+  - coverage report
   - python setup.py check -rm
-  - pip uninstall aiohttp && pip install aiohttp
+  - pip uninstall aiohttp -y && pip install aiohttp
   - python setup.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ install:
   - python setup.py develop
 
 script:
-  - flake8 aiohttp examples tests
+  - flake8 sockjs
   - coverage run --source=sockjs setup.py test
   - python setup.py check -rm
-
-script: python setup.py test
+  - pip uninstall aiohttp && pip install aiohttp
+  - python setup.py test

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,6 +9,7 @@ CHANGES
 - Fixed lost event-loop argument in `sockjs.transports.rawwebsocket.RawWebSocketTransport`
 - Fixed RawRequestMessage. Add raw_header argument (aiohttp 0.21+)
 - Fixed many warnings
+- Fixed `sockjs.route` add_endpoint without name bug
 
 0.3 (08/07/2015)
 ----------------

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,11 +2,12 @@
 CHANGES
 =======
 
-0.4 (02/02/2016)
+0.4 (02/XX/2016)
 ----------------
 
 - Fixed lost event-loop argument in `sockjs.transports.websocket.WebSocketTransport`
 - Fixed RawRequestMessage. Add raw_header argument (aiohttp 0.21+)
+- Fixed many warnings
 
 0.3 (08/07/2015)
 ----------------

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,6 +6,7 @@ CHANGES
 ----------------
 
 - Fixed lost event-loop argument in `sockjs.transports.websocket.WebSocketTransport`
+- Fixed lost event-loop argument in `sockjs.transports.rawwebsocket.RawWebSocketTransport`
 - Fixed RawRequestMessage. Add raw_header argument (aiohttp 0.21+)
 - Fixed many warnings
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,6 +2,12 @@
 CHANGES
 =======
 
+0.4 (02/02/2016)
+----------------
+
+- Fixed lost event-loop argument in `sockjs.transports.websocket.WebSocketTransport`
+- Fixed RawRequestMessage. Add raw_header argument (aiohttp 0.21+)
+
 0.3 (08/07/2015)
 ----------------
 
@@ -13,7 +19,6 @@ CHANGES
 ----------------
 
 - Fixed packaging
-
 
 0.1.0 (06/21/2015)
 ------------------

--- a/examples/chat.py
+++ b/examples/chat.py
@@ -30,7 +30,7 @@ if __name__ == '__main__':
 
     app = web.Application(loop=loop)
     app.router.add_route('GET', '/', index)
-    sockjs.add_endpoint(app, chat_msg_handler, prefix='/sockjs/')
+    sockjs.add_endpoint(app, chat_msg_handler, name='chat', prefix='/sockjs/')
 
     handler = app.make_handler()
     srv = loop.run_until_complete(

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,9 @@
 import os
 from setuptools import setup, find_packages
 
-version = '0.3'
+version = '0.4'
 
-install_requires = ['aiohttp >= 0.15.1']
+install_requires = ['aiohttp >= 0.18.0']
 tests_require = install_requires + ['nose']
 
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 version = '0.4'
 
-install_requires = ['aiohttp >= 0.18.0']
+install_requires = ['aiohttp >= 0.18.3']
 tests_require = install_requires + ['nose']
 
 

--- a/sockjs/__init__.py
+++ b/sockjs/__init__.py
@@ -2,12 +2,6 @@
 
 # Session, SessionManager are not imported
 
-__all__ = (
-    'get_manager', 'add_endpoint', 'Session', 'SessionManager',
-    'SessionIsClosed', 'SessionIsAcquired',
-    'STATE_NEW', 'STATE_OPEN', 'STATE_CLOSING', 'STATE_CLOSED',
-    'MSG_OPEN', 'MSG_MESSAGE', 'MSG_CLOSE', 'MSG_CLOSED',)
-
 from sockjs.session import Session
 from sockjs.session import SessionManager
 from sockjs.exceptions import SessionIsClosed
@@ -24,3 +18,9 @@ from sockjs.protocol import MSG_CLOSE
 from sockjs.protocol import MSG_CLOSED
 
 from sockjs.route import get_manager, add_endpoint
+
+__all__ = (
+    'get_manager', 'add_endpoint', 'Session', 'SessionManager',
+    'SessionIsClosed', 'SessionIsAcquired',
+    'STATE_NEW', 'STATE_OPEN', 'STATE_CLOSING', 'STATE_CLOSED',
+    'MSG_OPEN', 'MSG_MESSAGE', 'MSG_CLOSE', 'MSG_CLOSED',)

--- a/sockjs/route.py
+++ b/sockjs/route.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import random
 import logging
 import hashlib
@@ -6,7 +7,7 @@ import inspect
 from aiohttp import web, hdrs
 
 from sockjs.session import SessionManager
-from sockjs.protocol import IFRAME_HTML, json
+from sockjs.protocol import IFRAME_HTML
 from sockjs.transports import handlers
 from sockjs.transports.utils import session_cookie
 from sockjs.transports.utils import cors_headers
@@ -20,6 +21,10 @@ def get_manager(name, app):
     return app['__sockjs_managers__'][name]
 
 
+def _gen_endpoint_name():
+    return 'n' + str(random.randint(1000, 9999))
+
+
 def add_endpoint(app, handler, *, name='', prefix='/sockjs',
                  manager=None, disable_transports=(),
                  sockjs_cdn='http://cdn.sockjs.org/sockjs-0.3.4.min.js',
@@ -31,6 +36,9 @@ def add_endpoint(app, handler, *, name='', prefix='/sockjs',
         handler = asyncio.coroutine(handler)
 
     router = app.router
+
+    if not name:
+        name = _gen_endpoint_name()
 
     # set session manager
     if manager is None:

--- a/sockjs/transports/eventsource.py
+++ b/sockjs/transports/eventsource.py
@@ -29,7 +29,7 @@ class EventsourceTransport(StreamingTransport):
 
         # open sequence (sockjs protocol)
         resp = self.response = web.StreamResponse(headers=headers)
-        resp.start(self.request)
+        yield from resp.prepare(self.request)
         resp.write(b'\r\n')
 
         # handle session

--- a/sockjs/transports/htmlfile.py
+++ b/sockjs/transports/htmlfile.py
@@ -66,7 +66,7 @@ class HTMLFileTransport(StreamingTransport):
 
         # open sequence (sockjs protocol)
         resp = self.response = web.StreamResponse(headers=headers)
-        resp.start(self.request)
+        yield from resp.prepare(self.request)
         resp.write(b''.join(
             (PRELUDE1, callback.encode('utf-8'), PRELUDE2, b' '*1024)))
 

--- a/sockjs/transports/htmlfile.py
+++ b/sockjs/transports/htmlfile.py
@@ -49,12 +49,12 @@ class HTMLFileTransport(StreamingTransport):
         if callback is None:
             yield from self.session._remote_closed()
             return web.HTTPInternalServerError(
-              body=b'"callback" parameter required')
+                body=b'"callback" parameter required')
 
         elif not self.check_callback.match(callback):
             yield from self.session._remote_closed()
             return web.HTTPInternalServerError(
-              body=b'invalid "callback" parameter')
+                body=b'invalid "callback" parameter')
 
         headers = list(
             ((hdrs.CONTENT_TYPE, 'text/html; charset=UTF-8'),

--- a/sockjs/transports/htmlfile.py
+++ b/sockjs/transports/htmlfile.py
@@ -48,11 +48,13 @@ class HTMLFileTransport(StreamingTransport):
         callback = request.GET.get('c', None)
         if callback is None:
             yield from self.session._remote_closed()
-            return web.HTTPInternalServerError(body=b'"callback" parameter required')
+            return web.HTTPInternalServerError(
+              body=b'"callback" parameter required')
 
         elif not self.check_callback.match(callback):
             yield from self.session._remote_closed()
-            return web.HTTPInternalServerError(body=b'invalid "callback" parameter')
+            return web.HTTPInternalServerError(
+              body=b'invalid "callback" parameter')
 
         headers = list(
             ((hdrs.CONTENT_TYPE, 'text/html; charset=UTF-8'),

--- a/sockjs/transports/jsonp.py
+++ b/sockjs/transports/jsonp.py
@@ -73,7 +73,8 @@ class JSONPolling(StreamingTransport):
             try:
                 messages = loads(data)
             except:
-                return web.HTTPInternalServerError(body=b'Broken JSON encoding.')
+                return web.HTTPInternalServerError(
+                    body=b'Broken JSON encoding.')
 
             yield from session._remote_messages(messages)
             return web.Response(

--- a/sockjs/transports/jsonp.py
+++ b/sockjs/transports/jsonp.py
@@ -48,7 +48,7 @@ class JSONPolling(StreamingTransport):
                 cors_headers(request.headers))
 
             resp = self.response = web.StreamResponse(headers=headers)
-            resp.start(request)
+            yield from resp.prepare(request)
 
             yield from self.handle_session()
             return resp

--- a/sockjs/transports/jsonp.py
+++ b/sockjs/transports/jsonp.py
@@ -16,8 +16,8 @@ class JSONPolling(StreamingTransport):
     callback = ''
 
     def send(self, text):
-        blob = ('/**/%s(%s);\r\n' % (self.callback, dumps(text))).encode(ENCODING)
-        self.response.write(blob)
+        data = '/**/%s(%s);\r\n' % (self.callback, dumps(text))
+        self.response.write(data.encode(ENCODING))
         return True
 
     @asyncio.coroutine
@@ -59,14 +59,16 @@ class JSONPolling(StreamingTransport):
             ctype = request.content_type.lower()
             if ctype == 'application/x-www-form-urlencoded':
                 if not data.startswith(b'd='):
-                    return web.HTTPInternalServerError(body=b'Payload expected.')
+                    return web.HTTPInternalServerError(
+                        body=b'Payload expected.')
 
                 data = unquote_plus(data[2:].decode(ENCODING))
             else:
                 data = data.decode(ENCODING)
 
             if not data:
-                return web.HTTPInternalServerError(body=b'Payload expected.')
+                return web.HTTPInternalServerError(
+                    body=b'Payload expected.')
 
             try:
                 messages = loads(data)

--- a/sockjs/transports/rawwebsocket.py
+++ b/sockjs/transports/rawwebsocket.py
@@ -2,6 +2,11 @@
 import asyncio
 from aiohttp import web
 
+try:
+    from asyncio import ensure_future
+except ImportError:
+    ensure_future = asyncio.async
+
 from .base import Transport
 from ..exceptions import SessionIsClosed
 from ..protocol import FRAME_CLOSE, FRAME_MESSAGE
@@ -55,11 +60,12 @@ class RawWebSocketTransport(Transport):
             yield from ws.close(message='Go away!')
             return ws
 
-        server = asyncio.async(self.server(ws, self.session))
-        client = asyncio.async(self.client(ws, self.session))
+        server = ensure_future(self.server(ws, self.session), loop=self.loop)
+        client = ensure_future(self.client(ws, self.session), loop=self.loop)
         try:
             yield from asyncio.wait(
                 (server, client),
+                loop=self.loop,
                 return_when=asyncio.FIRST_COMPLETED)
         except asyncio.CancelledError:
             raise

--- a/sockjs/transports/rawwebsocket.py
+++ b/sockjs/transports/rawwebsocket.py
@@ -47,7 +47,7 @@ class RawWebSocketTransport(Transport):
     def process(self):
         # start websocket connection
         ws = self.ws = web.WebSocketResponse()
-        ws.start(self.request)
+        yield from ws.prepare(self.request)
 
         try:
             yield from self.manager.acquire(self.session)

--- a/sockjs/transports/websocket.py
+++ b/sockjs/transports/websocket.py
@@ -2,6 +2,11 @@
 import asyncio
 from aiohttp import web
 
+try:
+    from asyncio import ensure_future
+except ImportError:
+    ensure_future = asyncio.async
+
 from .base import Transport
 from ..exceptions import SessionIsClosed
 from ..protocol import STATE_CLOSED, FRAME_CLOSE
@@ -76,9 +81,9 @@ class WebSocketTransport(Transport):
                 yield from ws.close()
                 return ws
 
-            server = asyncio.ensure_future(
+            server = ensure_future(
                 self.server(ws, self.session), loop=self.loop)
-            client = asyncio.ensure_future(
+            client = ensure_future(
                 self.client(ws, self.session), loop=self.loop)
             try:
                 yield from asyncio.wait(

--- a/sockjs/transports/websocket.py
+++ b/sockjs/transports/websocket.py
@@ -59,7 +59,7 @@ class WebSocketTransport(Transport):
     def process(self):
         # start websocket connection
         ws = self.ws = web.WebSocketResponse()
-        ws.start(self.request)
+        yield from ws.prepare(self.request)
 
         # session was interrupted
         if self.session.interrupted:
@@ -76,11 +76,14 @@ class WebSocketTransport(Transport):
                 yield from ws.close()
                 return ws
 
-            server = asyncio.async(self.server(ws, self.session))
-            client = asyncio.async(self.client(ws, self.session))
+            server = asyncio.ensure_future(
+                self.server(ws, self.session), loop=self.loop)
+            client = asyncio.ensure_future(
+                self.client(ws, self.session), loop=self.loop)
             try:
                 yield from asyncio.wait(
                     (server, client),
+                    loop=self.loop,
                     return_when=asyncio.FIRST_COMPLETED)
             except asyncio.CancelledError:
                 raise

--- a/sockjs/transports/xhr.py
+++ b/sockjs/transports/xhr.py
@@ -32,7 +32,7 @@ class XHRTransport(StreamingTransport):
             cors_headers(request.headers))
 
         resp = self.response = web.StreamResponse(headers=headers)
-        resp.start(request)
+        yield from resp.prepare(request)
 
         yield from self.handle_session()
         return resp

--- a/sockjs/transports/xhrsend.py
+++ b/sockjs/transports/xhrsend.py
@@ -17,10 +17,11 @@ class XHRSendTransport(Transport):
             return web.HTTPForbidden(text='Method is not allowed')
 
         if self.request.method == hdrs.METH_OPTIONS:
+            base_headers = (
+                (hdrs.ACCESS_CONTROL_ALLOW_METHODS, 'OPTIONS, POST'),
+                (hdrs.CONTENT_TYPE, 'application/javascript; charset=UTF-8'))
             headers = list(
-                ((hdrs.ACCESS_CONTROL_ALLOW_METHODS, 'OPTIONS, POST'),
-                 (hdrs.CONTENT_TYPE, 'application/javascript; charset=UTF-8'))
-                +
+                base_headers +
                 session_cookie(request) +
                 cors_headers(request.headers) +
                 cache_headers())

--- a/sockjs/transports/xhrstreaming.py
+++ b/sockjs/transports/xhrstreaming.py
@@ -31,7 +31,7 @@ class XHRStreamingTransport(StreamingTransport):
         # open sequence (sockjs protocol)
         resp = self.response = web.StreamResponse(headers=headers)
         resp.force_close()
-        resp.start(request)
+        yield from resp.prepare(request)
         resp.write(self.open_seq)
 
         # event loop

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -50,12 +50,19 @@ class TestCase(unittest.TestCase):
                  'ORIGIN': 'http://example.com',
                  'SEC-WEBSOCKET-PROTOCOL': 'chat, superchat',
                  'SEC-WEBSOCKET-VERSION': '13'})
+
+        @asyncio.coroutine
+        def mock_coro(*args, **kwargs):
+            return
+
         message = make_raw_request_message(method, path, headers)
         self.payload = mock.Mock()
         self.transport = mock.Mock()
         self.reader = mock.Mock()
         self.writer = mock.Mock()
         self.app.loop = self.loop
+        # hack for `yield from resp.prepare(self.request)`
+        self.app.on_response_prepare.send = mock_coro
         req = web.Request(self.app, message, self.payload,
                           self.transport, self.reader, self.writer)
         req._match_info = match_info

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -33,7 +33,9 @@ class TestCase(unittest.TestCase):
                  'SEC-WEBSOCKET-PROTOCOL': 'chat, superchat',
                  'SEC-WEBSOCKET-VERSION': '13'})
         message = RawRequestMessage(
-            method, path, HttpVersion11, headers, False, False)
+            method, path, HttpVersion11, headers, 
+            [(k.encode('utf-8'), v.encode('utf-8')) for k, v in headers.items()],
+            False, False)
         self.payload = mock.Mock()
         self.transport = mock.Mock()
         self.reader = mock.Mock()

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -2,8 +2,26 @@ import asyncio
 import unittest
 import urllib.parse
 from unittest import mock
+
 from aiohttp import web, CIMultiDict
 from aiohttp.protocol import RawRequestMessage, HttpVersion11
+from sockjs import session, route, transports
+
+
+def make_raw_request_message(method, path, headers, version=HttpVersion11,
+                             should_close=False, compression=False):
+    raw_headers = [(k.encode('utf-8'), v.encode('utf-8'))
+                   for k, v in headers.items()]
+    try:
+        message = RawRequestMessage(method=method, path=path, headers=headers,
+                                    raw_headers=raw_headers,
+                                    version=version, should_close=should_close,
+                                    compression=compression)
+    except TypeError:  # aiohttp < 0.21.x
+        message = RawRequestMessage(method=method, path=path, headers=headers,
+                                    version=version, should_close=should_close,
+                                    compression=compression)
+    return message
 
 
 class TestCase(unittest.TestCase):
@@ -32,10 +50,7 @@ class TestCase(unittest.TestCase):
                  'ORIGIN': 'http://example.com',
                  'SEC-WEBSOCKET-PROTOCOL': 'chat, superchat',
                  'SEC-WEBSOCKET-VERSION': '13'})
-        message = RawRequestMessage(
-            method, path, HttpVersion11, headers, 
-            [(k.encode('utf-8'), v.encode('utf-8')) for k, v in headers.items()],
-            False, False)
+        message = make_raw_request_message(method, path, headers)
         self.payload = mock.Mock()
         self.transport = mock.Mock()
         self.reader = mock.Mock()
@@ -63,3 +78,55 @@ class TestCase(unittest.TestCase):
         session._remote_closed = self.make_fut(1)
         request = self.make_request(method, path, query_params=query_params)
         return self.TRANSPORT_CLASS(manager, session, request)
+
+
+class BaseSockjs(unittest.TestCase):
+
+    def setUp(self):
+        self.loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(None)
+
+        self.app = web.Application(loop=self.loop)
+
+    def tearDown(self):
+        self.loop.close()
+
+    def make_handler(self, result, coro=True):
+
+        output = result
+
+        def handler(msg, s):
+            output.append(output)
+
+        if coro:
+            return asyncio.coroutine(handler)
+        else:
+            return handler
+
+    def make_route(self, handlers=transports.handlers):
+        handler = self.make_handler([])
+        sm = session.SessionManager('sm', self.app, handler, loop=self.loop)
+        return route.SockJSRoute(
+            'sm', sm, 'http:sockjs-cdn', handlers, (), True)
+
+    def make_request(self, method, path, headers=None, match_info=None):
+        self.app = mock.Mock()
+        if headers is None:
+            headers = CIMultiDict(
+                {'HOST': 'server.example.com',
+                 'UPGRADE': 'websocket',
+                 'CONNECTION': 'Upgrade',
+                 'SEC-WEBSOCKET-KEY': 'dGhlIHNhbXBsZSBub25jZQ==',
+                 'ORIGIN': 'http://example.com',
+                 'SEC-WEBSOCKET-PROTOCOL': 'chat, superchat',
+                 'SEC-WEBSOCKET-VERSION': '13'})
+        message = make_raw_request_message(method, path, headers)
+        self.payload = mock.Mock()
+        self.transport = mock.Mock()
+        self.reader = mock.Mock()
+        self.writer = mock.Mock()
+        self.app.loop = self.loop
+        req = web.Request(self.app, message, self.payload,
+                          self.transport, self.reader, self.writer)
+        req._match_info = match_info
+        return req

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,11 +1,16 @@
 import asyncio
 import unittest
 import urllib.parse
+from datetime import timedelta
 from unittest import mock
 
-from aiohttp import web, CIMultiDict
+from aiohttp import CIMultiDict
+from aiohttp.web import Request, Application
 from aiohttp.protocol import RawRequestMessage, HttpVersion11
-from sockjs import session, route, transports
+from aiohttp.signals import Signal
+
+from sockjs import Session, SessionManager, transports
+from sockjs.route import SockJSRoute
 
 
 def make_raw_request_message(method, path, headers, version=HttpVersion11,
@@ -24,23 +29,26 @@ def make_raw_request_message(method, path, headers, version=HttpVersion11,
     return message
 
 
-class TestCase(unittest.TestCase):
-
-    TRANSPORT_CLASS = None
+class BaseTestCase(unittest.TestCase):
 
     def setUp(self):
+        super().setUp()
         self.loop = asyncio.new_event_loop()
         asyncio.set_event_loop(None)
 
     def tearDown(self):
+        super().tearDown()
         self.loop.close()
 
-    def make_request(self, method, path,
-                     query_params={}, headers=None, match_info=None):
+    def make_request(self, method, path, query_params={}, headers=None,
+                     match_info=None):
         if query_params:
             path = '%s?%s' % (path, urllib.parse.urlencode(query_params))
 
+        # Ported from:
+        # https://github.com/KeepSafe/aiohttp/blob/fa06acc2392c516491bdb25301ad3ef2b700ff5f/tests/test_web_websocket.py#L21-L45  # noqa
         self.app = mock.Mock()
+        self.app._debug = False
         if headers is None:
             headers = CIMultiDict(
                 {'HOST': 'server.example.com',
@@ -51,20 +59,15 @@ class TestCase(unittest.TestCase):
                  'SEC-WEBSOCKET-PROTOCOL': 'chat, superchat',
                  'SEC-WEBSOCKET-VERSION': '13'})
 
-        @asyncio.coroutine
-        def mock_coro(*args, **kwargs):
-            return
-
         message = make_raw_request_message(method, path, headers)
         self.payload = mock.Mock()
         self.transport = mock.Mock()
         self.reader = mock.Mock()
         self.writer = mock.Mock()
         self.app.loop = self.loop
-        # hack for `yield from resp.prepare(self.request)`
-        self.app.on_response_prepare.send = mock_coro
-        req = web.Request(self.app, message, self.payload,
-                          self.transport, self.reader, self.writer)
+        self.app.on_response_prepare = Signal(self.app)
+        req = Request(self.app, message, self.payload,
+                      self.transport, self.reader, self.writer)
         req._match_info = match_info
         return req
 
@@ -79,6 +82,20 @@ class TestCase(unittest.TestCase):
         else:
             return fut
 
+
+class BaseSockjsTestCase(BaseTestCase):
+
+    TRANSPORT_CLASS = None
+
+    def setUp(self):
+        super().setUp()
+        self.app = Application(loop=self.loop)
+
+    def make_route(self, handlers=transports.handlers):
+        handler = self.make_handler([])
+        sm = SessionManager('sm', self.app, handler, loop=self.loop)
+        return SockJSRoute('sm', sm, 'http:sockjs-cdn', handlers, (), True)
+
     def make_transport(self, method='GET', path='/', query_params={}):
         manager = mock.Mock()
         session = mock.Mock()
@@ -86,54 +103,31 @@ class TestCase(unittest.TestCase):
         request = self.make_request(method, path, query_params=query_params)
         return self.TRANSPORT_CLASS(manager, session, request)
 
+    def make_session(self, name='test', timeout=timedelta(10), handler=None,
+                     result=None):
+        if handler is None:
+            handler = self.make_handler(result)
+        return Session(name, handler,
+                       timeout=timeout, loop=self.loop, debug=True)
 
-class BaseSockjs(unittest.TestCase):
+    def make_manager(self, handler=None):
+        if handler is None:
+            handler = self.make_handler([])
+        s = self.make_session('test', handler=handler)
+        return s, SessionManager(
+            'sm', self.app, handler, loop=self.loop, debug=True)
 
-    def setUp(self):
-        self.loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(None)
-
-        self.app = web.Application(loop=self.loop)
-
-    def tearDown(self):
-        self.loop.close()
-
-    def make_handler(self, result, coro=True):
-
+    def make_handler(self, result, coro=True, exc=False):
+        if result is None:
+            result = []
         output = result
 
         def handler(msg, s):
-            output.append(output)
+            if exc:
+                raise ValueError((msg, s))
+            output.append((msg, s))
 
         if coro:
             return asyncio.coroutine(handler)
         else:
             return handler
-
-    def make_route(self, handlers=transports.handlers):
-        handler = self.make_handler([])
-        sm = session.SessionManager('sm', self.app, handler, loop=self.loop)
-        return route.SockJSRoute(
-            'sm', sm, 'http:sockjs-cdn', handlers, (), True)
-
-    def make_request(self, method, path, headers=None, match_info=None):
-        self.app = mock.Mock()
-        if headers is None:
-            headers = CIMultiDict(
-                {'HOST': 'server.example.com',
-                 'UPGRADE': 'websocket',
-                 'CONNECTION': 'Upgrade',
-                 'SEC-WEBSOCKET-KEY': 'dGhlIHNhbXBsZSBub25jZQ==',
-                 'ORIGIN': 'http://example.com',
-                 'SEC-WEBSOCKET-PROTOCOL': 'chat, superchat',
-                 'SEC-WEBSOCKET-VERSION': '13'})
-        message = make_raw_request_message(method, path, headers)
-        self.payload = mock.Mock()
-        self.transport = mock.Mock()
-        self.reader = mock.Mock()
-        self.writer = mock.Mock()
-        self.app.loop = self.loop
-        req = web.Request(self.app, message, self.payload,
-                          self.transport, self.reader, self.writer)
-        req._match_info = match_info
-        return req

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -1,5 +1,6 @@
 import json
 import unittest
+
 from sockjs import protocol
 
 

--- a/tests/test_route.py
+++ b/tests/test_route.py
@@ -48,9 +48,10 @@ class BaseSockjs(unittest.TestCase):
                  'ORIGIN': 'http://example.com',
                  'SEC-WEBSOCKET-PROTOCOL': 'chat, superchat',
                  'SEC-WEBSOCKET-VERSION': '13'})
-        message = RawRequestMessage(method, path, HttpVersion11, headers,
-                                    [(k.encode('utf-8'), v.encode('utf-8')) for k, v in headers.items()]
-                                    False, False)
+        message = RawRequestMessage(
+            method, path, HttpVersion11, headers,
+            [(k.encode('utf-8'), v.encode('utf-8')) for k, v in headers.items()],
+            False, False)
         self.payload = mock.Mock()
         self.transport = mock.Mock()
         self.reader = mock.Mock()

--- a/tests/test_route.py
+++ b/tests/test_route.py
@@ -1,66 +1,12 @@
 import asyncio
-import unittest
 from unittest import mock
 
 from aiohttp import web
 from aiohttp import CIMultiDict
-from aiohttp.protocol import RawRequestMessage, HttpVersion11
-from sockjs import session, route, protocol, transports
 
+from sockjs import protocol
 
-class BaseSockjs(unittest.TestCase):
-
-    def setUp(self):
-        self.loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(None)
-
-        self.app = web.Application(loop=self.loop)
-
-    def tearDown(self):
-        self.loop.close()
-
-    def make_handler(self, result, coro=True):
-
-        output = result
-
-        def handler(msg, s):
-            output.append(output)
-
-        if coro:
-            return asyncio.coroutine(handler)
-        else:
-            return handler
-
-    def make_route(self, handlers=transports.handlers):
-        handler = self.make_handler([])
-        sm = session.SessionManager('sm', self.app, handler, loop=self.loop)
-        return route.SockJSRoute(
-            'sm', sm, 'http:sockjs-cdn', handlers, (), True)
-
-    def make_request(self, method, path, headers=None, match_info=None):
-        self.app = mock.Mock()
-        if headers is None:
-            headers = CIMultiDict(
-                {'HOST': 'server.example.com',
-                 'UPGRADE': 'websocket',
-                 'CONNECTION': 'Upgrade',
-                 'SEC-WEBSOCKET-KEY': 'dGhlIHNhbXBsZSBub25jZQ==',
-                 'ORIGIN': 'http://example.com',
-                 'SEC-WEBSOCKET-PROTOCOL': 'chat, superchat',
-                 'SEC-WEBSOCKET-VERSION': '13'})
-        message = RawRequestMessage(
-            method, path, HttpVersion11, headers,
-            [(k.encode('utf-8'), v.encode('utf-8')) for k, v in headers.items()],
-            False, False)
-        self.payload = mock.Mock()
-        self.transport = mock.Mock()
-        self.reader = mock.Mock()
-        self.writer = mock.Mock()
-        self.app.loop = self.loop
-        req = web.Request(self.app, message, self.payload,
-                          self.transport, self.reader, self.writer)
-        req._match_info = match_info
-        return req
+from test_base import BaseSockjs
 
 
 class TestSockJSRoute(BaseSockjs):

--- a/tests/test_route.py
+++ b/tests/test_route.py
@@ -49,6 +49,7 @@ class BaseSockjs(unittest.TestCase):
                  'SEC-WEBSOCKET-PROTOCOL': 'chat, superchat',
                  'SEC-WEBSOCKET-VERSION': '13'})
         message = RawRequestMessage(method, path, HttpVersion11, headers,
+                                    [(k.encode('utf-8'), v.encode('utf-8')) for k, v in headers.items()]
                                     False, False)
         self.payload = mock.Mock()
         self.transport = mock.Mock()

--- a/tests/test_route.py
+++ b/tests/test_route.py
@@ -6,10 +6,10 @@ from aiohttp import CIMultiDict
 
 from sockjs import protocol
 
-from test_base import BaseSockjs
+from test_base import BaseSockjsTestCase
 
 
-class TestSockJSRoute(BaseSockjs):
+class TestSockJSRoute(BaseSockjsTestCase):
 
     def test_info(self):
         route = self.make_route()

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -3,6 +3,11 @@ import unittest
 from unittest import mock
 from datetime import datetime, timedelta
 
+try:
+    from asyncio import ensure_future
+except ImportError:
+    ensure_future = asyncio.async
+
 from aiohttp import web
 from sockjs import Session, session, protocol
 
@@ -216,7 +221,7 @@ class SessionTestCase(unittest.TestCase):
             yield from asyncio.sleep(0.001, loop=self.loop)
             s._feed(protocol.FRAME_MESSAGE, 'msg1')
 
-        asyncio.async(send(), loop=self.loop)
+        ensure_future(send(), loop=self.loop)
         frame, payload = self.loop.run_until_complete(s._wait())
         self.assertEqual(frame, protocol.FRAME_MESSAGE)
         self.assertEqual(payload, 'a["msg1"]')

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -1,9 +1,10 @@
 from unittest import mock
 from aiohttp import web
-from test_base import TestCase
 
 from sockjs import protocol
 from sockjs.transports import base
+
+from test_base import TestCase
 
 
 class TransportTestCase(TestCase):

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -4,10 +4,10 @@ from aiohttp import web
 from sockjs import protocol
 from sockjs.transports import base
 
-from test_base import TestCase
+from test_base import BaseSockjsTestCase
 
 
-class TransportTestCase(TestCase):
+class TransportTestCase(BaseSockjsTestCase):
 
     TRANSPORT_CLASS = base.StreamingTransport
 

--- a/tests/test_transport_eventsource.py
+++ b/tests/test_transport_eventsource.py
@@ -1,13 +1,16 @@
 from unittest import mock
 
-from sockjs.transports import eventsource
+from aiohttp import websocket
+from aiohttp.web_ws import WebSocketResponse
 
-from test_base import TestCase
+from sockjs.transports import EventsourceTransport, WebSocketTransport
+
+from test_base import BaseSockjsTestCase
 
 
-class EventsourceTransportTests(TestCase):
+class EventsourceTransportTests(BaseSockjsTestCase):
 
-    TRANSPORT_CLASS = eventsource.EventsourceTransport
+    TRANSPORT_CLASS = EventsourceTransport
 
     def test_streaming_send(self):
         trans = self.make_transport()

--- a/tests/test_transport_eventsource.py
+++ b/tests/test_transport_eventsource.py
@@ -1,7 +1,8 @@
 from unittest import mock
-from test_base import TestCase
 
 from sockjs.transports import eventsource
+
+from test_base import TestCase
 
 
 class EventsourceTransportTests(TestCase):

--- a/tests/test_transport_htmlfile.py
+++ b/tests/test_transport_htmlfile.py
@@ -1,7 +1,8 @@
 from unittest import mock
-from test_base import TestCase
 
 from sockjs.transports import htmlfile
+
+from test_base import TestCase
 
 
 class HtmlFileTransportTests(TestCase):

--- a/tests/test_transport_htmlfile.py
+++ b/tests/test_transport_htmlfile.py
@@ -2,10 +2,10 @@ from unittest import mock
 
 from sockjs.transports import htmlfile
 
-from test_base import TestCase
+from test_base import BaseSockjsTestCase
 
 
-class HtmlFileTransportTests(TestCase):
+class HtmlFileTransportTests(BaseSockjsTestCase):
 
     TRANSPORT_CLASS = htmlfile.HTMLFileTransport
 

--- a/tests/test_transport_jsonp.py
+++ b/tests/test_transport_jsonp.py
@@ -2,10 +2,10 @@ from unittest import mock
 
 from sockjs.transports import jsonp
 
-from test_base import TestCase
+from test_base import BaseSockjsTestCase
 
 
-class JSONPollingTransportTests(TestCase):
+class JSONPollingTransportTests(BaseSockjsTestCase):
 
     TRANSPORT_CLASS = jsonp.JSONPolling
 

--- a/tests/test_transport_jsonp.py
+++ b/tests/test_transport_jsonp.py
@@ -1,7 +1,8 @@
 from unittest import mock
-from test_base import TestCase
 
 from sockjs.transports import jsonp
+
+from test_base import TestCase
 
 
 class JSONPollingTransportTests(TestCase):

--- a/tests/test_transport_websocket.py
+++ b/tests/test_transport_websocket.py
@@ -1,0 +1,38 @@
+import asyncio
+
+from sockjs.transports import WebSocketTransport
+
+from test_base import BaseSockjsTestCase
+
+
+class WebSocketTransportTests(BaseSockjsTestCase):
+    TRANSPORT_CLASS = WebSocketTransport
+
+    def make_mock_coro(self, return_value=None, raise_exception=None):
+
+        @asyncio.coroutine
+        def maked_coro(*args, **kwargs):
+            maked_coro.called = True
+            maked_coro.args = args
+            maked_coro.kwargs = kwargs
+            if raise_exception:
+                raise raise_exception
+            return return_value
+
+        maked_coro.called = False
+
+        return maked_coro
+
+    def test_process_release_acquire_and_remote_closed(self):
+        transp = self.make_transport()
+        transp.session.interrupted = False
+        transp.manager.acquire = self.make_mock_coro()
+        transp.manager.release = self.make_mock_coro()
+        resp = self.loop.run_until_complete(transp.process())
+        self.assertEqual(resp.status, 101)
+        self.assertEqual(resp.headers.get('upgrade', '').lower(), 'websocket')
+        self.assertEqual(resp.headers.get('connection', '').lower(), 'upgrade')
+
+        transp.session._remote_closed.assert_called_once_with()
+        self.assertTrue(transp.manager.acquire.called)
+        self.assertTrue(transp.manager.release.called)

--- a/tests/test_transport_xhr.py
+++ b/tests/test_transport_xhr.py
@@ -1,5 +1,6 @@
-from test_base import TestCase
 from sockjs.transports import xhr
+
+from test_base import TestCase
 
 
 class XhrTransportTests(TestCase):

--- a/tests/test_transport_xhr.py
+++ b/tests/test_transport_xhr.py
@@ -1,9 +1,9 @@
 from sockjs.transports import xhr
 
-from test_base import TestCase
+from test_base import BaseSockjsTestCase
 
 
-class XhrTransportTests(TestCase):
+class XhrTransportTests(BaseSockjsTestCase):
 
     TRANSPORT_CLASS = xhr.XHRTransport
 

--- a/tests/test_transport_xhrsend.py
+++ b/tests/test_transport_xhrsend.py
@@ -1,9 +1,9 @@
 from sockjs.transports import xhrsend
 
-from test_base import TestCase
+from test_base import BaseSockjsTestCase
 
 
-class XHRSendTransportTests(TestCase):
+class XHRSendTransportTests(BaseSockjsTestCase):
 
     TRANSPORT_CLASS = xhrsend.XHRSendTransport
 

--- a/tests/test_transport_xhrsend.py
+++ b/tests/test_transport_xhrsend.py
@@ -1,5 +1,6 @@
-from test_base import TestCase
 from sockjs.transports import xhrsend
+
+from test_base import TestCase
 
 
 class XHRSendTransportTests(TestCase):

--- a/tests/test_transport_xhrstreaming.py
+++ b/tests/test_transport_xhrstreaming.py
@@ -1,9 +1,9 @@
 from sockjs.transports import xhrstreaming
 
-from test_base import TestCase
+from test_base import BaseSockjsTestCase
 
 
-class XHRStreamingTransportTests(TestCase):
+class XHRStreamingTransportTests(BaseSockjsTestCase):
 
     TRANSPORT_CLASS = xhrstreaming.XHRStreamingTransport
 

--- a/tests/test_transport_xhrstreaming.py
+++ b/tests/test_transport_xhrstreaming.py
@@ -1,6 +1,6 @@
-from test_base import TestCase
-
 from sockjs.transports import xhrstreaming
+
+from test_base import TestCase
 
 
 class XHRStreamingTransportTests(TestCase):


### PR DESCRIPTION
Hi. I finde some problems with the lose event loop on my tests. 

Warnings:
```
\venv\lib\site-packages\aiohttp\web_ws.py:80: DeprecationWarning: use .prepare(request) instead
  warnings.warn('use .prepare(request) instead', DeprecationWarning)
venv\lib\site-packages\aiohttp\web_reqrep.py:675: DeprecationWarning: use .prepare(request) instead
  warnings.warn('use .prepare(request) instead', DeprecationWarning)
Python35\lib\asyncio\tasks.py:522: DeprecationWarning: asyncio.async() function is deprecated, use ensure_future()
  DeprecationWarning)
```

Now I have only one warning:
```
<CoroWrapper SessionManager.clear() running at venv\lib\site-packages\sockjs\session.py:388, created at venv\lib\site-packages\sockjs\session.py:406> was never yielded from
Coroutine object created at (most recent call last):
  File "venv\lib\site-packages\sockjs\session.py", line 406, in __del__
    self.clear()
```

I think this is correct.