### PR TITLE
[Websocket] Closing session never break receive loop

### DIFF
--- a/sockjs/transports/websocket.py
+++ b/sockjs/transports/websocket.py
@@ -56,7 +56,7 @@ class WebSocketTransport(Transport):
 
             elif msg.tp == web.MsgType.close:
                 yield from session._remote_close()
-            elif msg.tp == web.MsgType.closed:
+            elif msg.tp in (web.MsgType.closed, web.MsgType.closing):
                 yield from session._remote_closed()
                 break
 


### PR DESCRIPTION
When i shutdown my aiohttp application i got stuck to 60 seconds.
Closing active sessions did not help. So, i'm starting investigation and think found a bug.

1. we call `session.close()`
1.1 [`session` feed FRAME_CLOSE](https://github.com/aio-libs/sockjs/blob/master/sockjs/session.py#L255)
1.2 [websocket transport handle FAME_CLOSE and call `ws.close()`](https://github.com/aio-libs/sockjs/blob/master/sockjs/transports/websocket.py#L30)

2. [aiohttp `ws.close()` feed `WS_CLOSING_MESSAGE` to break `receive()` cycle](https://github.com/aio-libs/aiohttp/blob/master/aiohttp/web_ws.py#L210)
3. [websocket transport got this message and receive it again and again, without breaking loop](https://github.com/aio-libs/sockjs/blob/master/sockjs/transports/websocket.py#L37)

This PR fix it and now SIGTERM "instantly" shutdown the server.