### PR TITLE
add possibility to use custom SessionManager with async 'get' method

### DIFF
--- a/sockjs/route.py
+++ b/sockjs/route.py
@@ -139,7 +139,7 @@ class SockJSRoute:
             return web.HTTPNotFound()
 
         try:
-            session = manager.get(sid, create, request=request)
+            session = yield from manager.get(sid, create, request=request)
         except KeyError:
             return web.HTTPNotFound(headers=session_cookie(request))
 
@@ -160,7 +160,7 @@ class SockJSRoute:
     def websocket(self, request):
         # session
         sid = '%0.9d' % random.randint(1, 2147483647)
-        session = self.manager.get(sid, True, request=request)
+        session = yield from self.manager.get(sid, True, request=request)
 
         transport = RawWebSocketTransport(self.manager, session, request)
         try:

--- a/sockjs/session.py
+++ b/sockjs/session.py
@@ -347,6 +347,7 @@ class SessionManager(dict):
         self.sessions.append(session)
         return session
 
+    @asyncio.coroutine
     def get(self, id, create=False, request=None, default=_marker):
         session = super(SessionManager, self).get(id, None)
         if session is None:


### PR DESCRIPTION
This PR allow to use `aiohttp_security.authorized_userid` inside an optionally async get method of a custom SessionManager.
Currently tests are missing because I need some hint about how to proceed.