### PR TITLE
aiohttp 3.0.6 compat

### DIFF
--- a/sockjs/transports/rawwebsocket.py
+++ b/sockjs/transports/rawwebsocket.py
@@ -42,15 +42,15 @@ class RawWebSocketTransport(Transport):
         while True:
             msg = await ws.receive()
 
-            if msg.type == web.MsgType.text:
+            if msg.type == web.WSMsgType.text:
                 if not msg.data:
                     continue
 
                 await self.session._remote_message(msg.data)
 
-            elif msg.type == web.MsgType.close:
+            elif msg.type == web.WSMsgType.close:
                 await self.session._remote_close()
-            elif msg.type == web.MsgType.closed:
+            elif msg.type == web.WSMsgType.closed:
                 await self.session._remote_closed()
                 break
 


### PR DESCRIPTION
```
future: <Task finished coro=<RawWebSocketTransport.client() done, defined at venv/lib/python3.6/site-packages/sockjs/transports/rawwebsocket.py:41> exception=AttributeError("module 'aiohttp.web' has no attribute 'MsgType'",)>
Traceback (most recent call last):
  File "venv/lib/python3.6/site-packages/sockjs/transports/rawwebsocket.py", line 45, in client
    if msg.type == web.MsgType.text:
AttributeError: module 'aiohttp.web' has no attribute 'MsgType'
```

Was changed in this commit:

https://github.com/aio-libs/aiohttp/commit/461173fbc2266f619b56256281f7a245e7d56da3