### PR TITLE
Fix heartbeat

### DIFF
--- a/sockjs/session.py
+++ b/sockjs/session.py
@@ -81,8 +81,6 @@ class Session(object):
         return ' '.join(result)
 
     def _tick(self, timeout=None):
-        self.expired = False
-
         if timeout is None:
             self.expires = datetime.now() + self.timeout
         else:
@@ -117,8 +115,6 @@ class Session(object):
         self._heartbeat_transport = False
 
     def _heartbeat(self):
-        self.expired = False
-        self._tick()
         self._heartbeats += 1
         if self._heartbeat:
             self._feed(FRAME_HEARTBEAT, FRAME_HEARTBEAT)
@@ -225,7 +221,6 @@ class Session(object):
         if self.state != STATE_OPEN:
             return
 
-        self._tick()
         self._feed(FRAME_MESSAGE, msg)
 
     def send_frame(self, frm):
@@ -236,7 +231,6 @@ class Session(object):
         if self.state != STATE_OPEN:
             return
 
-        self._tick()
         self._feed(FRAME_MESSAGE_BLOB, frm)
 
     def close(self, code=3000, reason='Go away!'):
@@ -261,7 +255,7 @@ class SessionManager(dict):
     _hb_task = None  # gc task
 
     def __init__(self, name, app, handler, loop,
-                 heartbeat=25.0, timeout=timedelta(seconds=5), debug=False):
+                 heartbeat=25.0, timeout=timedelta(seconds=40), debug=False):
         self.name = name
         self.route_name = 'sockjs-url-%s' % name
         self.app = app
@@ -309,10 +303,9 @@ class SessionManager(dict):
             while idx < len(sessions):
                 session = sessions[idx]
 
-                if session.acquired:
-                    session._heartbeat()
+                session._heartbeat()
 
-                elif session.expires < now:
+                if session.expires < now:
                     # Session is to be GC'd immedietely
                     if session.id in self.acquired:
                         await self.release(session)

--- a/sockjs/transports/rawwebsocket.py
+++ b/sockjs/transports/rawwebsocket.py
@@ -51,10 +51,12 @@ class RawWebSocketTransport(Transport):
             elif msg.type in (web.WSMsgType.closed, web.WSMsgType.closing):
                 await self.session._remote_closed()
                 break
+            elif msg.type == web.WSMsgType.PONG:
+                self.session._tick()
 
     async def process(self):
         # start websocket connection
-        ws = self.ws = web.WebSocketResponse()
+        ws = self.ws = web.WebSocketResponse(autoping=False)
         await ws.prepare(self.request)
 
         try:

--- a/tests/test_transport_rawwebsocket.py
+++ b/tests/test_transport_rawwebsocket.py
@@ -1,0 +1,67 @@
+from unittest import mock
+from asyncio import Future
+
+import pytest
+
+from sockjs.exceptions import SessionIsClosed
+from sockjs.protocol import FRAME_CLOSE, FRAME_HEARTBEAT
+from sockjs.transports.rawwebsocket import RawWebSocketTransport
+
+from aiohttp import WSMessage, WSMsgType
+
+
+@pytest.fixture
+def make_transport(make_request, make_fut):
+    def maker(method='GET', path='/', query_params={}):
+        manager = mock.Mock()
+        session = mock.Mock()
+        session._remote_closed = make_fut(1)
+        session._wait = make_fut((FRAME_CLOSE, ''))
+        request = make_request(method, path, query_params=query_params)
+        request.app.freeze()
+        return RawWebSocketTransport(manager, session, request)
+
+    return maker
+
+
+async def test_ticks_pong(make_transport, make_fut):
+    transp = make_transport()
+
+    pong = WSMessage(type=WSMsgType.PONG, data=b'', extra='')
+    close = WSMessage(type=WSMsgType.closing, data=b'', extra='')
+
+    future = Future()
+    future.set_result(pong)
+
+    future2 = Future()
+    future2.set_result(close)
+
+    ws = mock.Mock()
+    ws.receive.side_effect = [future, future2]
+
+    session = transp.session
+
+    await transp.client(ws, session)
+    assert session._tick.called
+
+
+async def test_sends_ping(make_transport, make_fut):
+    transp = make_transport()
+
+    future = Future()
+    future.set_result(False)
+
+    ws = mock.Mock()
+    ws.ping.side_effect = [future]
+
+    hb_future = Future()
+    hb_future.set_result((FRAME_HEARTBEAT, b''))
+
+    session_close_future = Future()
+    session_close_future.set_exception(SessionIsClosed)
+
+    session = mock.Mock()
+    session._wait.side_effect = [hb_future, session_close_future]
+
+    await transp.server(ws, session)
+    assert ws.ping.called


### PR DESCRIPTION
Fixed/Added heartbeat from SessionManager control for RawWebsocket Transport.
I think this transport should behave the same way as "normal" transport. Especially for the cleanup part.

`The acquired session can not be expired` <-- This is thus removed.

Oh, and btw, with this PR it also removes the _tick call on send. Which means now things can actually timeout if it does not receive any data from client. (I think that before they could never time out due to this.)