### PR TITLE
Fix race condition during iteration over sessions

### DIFF
--- a/sockjs/session.py
+++ b/sockjs/session.py
@@ -374,7 +374,7 @@ class SessionManager(dict):
             del self.acquired[s.id]
 
     def active_sessions(self):
-        for session in self.values():
+        for session in list(self.values()):
             if not session.expired:
                 yield session
 
@@ -390,7 +390,7 @@ class SessionManager(dict):
     def broadcast(self, message):
         blob = message_frame(message)
 
-        for session in self.values():
+        for session in list(self.values()):
             if not session.expired:
                 session.send_frame(blob)
 


### PR DESCRIPTION
Sessions are stored in a dict object, but values() method provides a
memoryview of that dict and does not copy data. Therefore, race
conditions are possible in cases when dict is changed during an
iteration over its memoryview.

This fixes issue #218 