### PR TITLE
Fix heartbeat for websocket

### DIFF
--- a/sockjs/transports/websocket.py
+++ b/sockjs/transports/websocket.py
@@ -9,7 +9,7 @@ except ImportError:  # pragma: no cover
 
 from .base import Transport
 from ..exceptions import SessionIsClosed
-from ..protocol import STATE_CLOSED, FRAME_CLOSE
+from ..protocol import STATE_CLOSED, FRAME_CLOSE, FRAME_HEARTBEAT
 from ..protocol import loads, close_frame
 
 
@@ -28,6 +28,9 @@ class WebSocketTransport(Transport):
                     await ws.close()
                 finally:
                     await session._remote_closed()
+            elif frame == FRAME_HEARTBEAT:
+                self.session._tick()
+
 
     async def client(self, ws, session):
         while True:


### PR DESCRIPTION
It seems that this [commit](https://github.com/aio-libs/sockjs/commit/9c29e9921f815c0146882abab1240cd80473f4ab#diff-c4ae142f5c8b2a63ea9689afef142593L84) breaks heartbeat for websocket. Currently examples/chat.py not working well, if websocket is used then the connection will be closed after session timeout (of course with correct values in timeout and heartbeat). I am note sure that my commit does it well because I do not fully understated current code, bu it fixes the problem.  