### PR TITLE
Solution to session closed by bad timeout and no _tick on frame heartbeat.

### DIFF
--- a/sockjs/session.py
+++ b/sockjs/session.py
@@ -42,7 +42,7 @@ class Session(object):
     exception = None
 
     def __init__(self, id, handler, request, *,
-                 timeout=timedelta(seconds=10), loop=None, debug=False):
+                 timeout=timedelta(seconds=40), loop=None, debug=False):
         self.id = id
         self.handler = handler
         self.request = request
@@ -255,7 +255,7 @@ class SessionManager(dict):
     _hb_task = None  # gc task
 
     def __init__(self, name, app, handler, loop,
-                 heartbeat=25.0, timeout=timedelta(seconds=5), debug=False):
+                 heartbeat=25.0, timeout=timedelta(seconds=40), debug=False):
         self.name = name
         self.route_name = 'sockjs-url-%s' % name
         self.app = app

--- a/sockjs/transports/websocket.py
+++ b/sockjs/transports/websocket.py
@@ -9,7 +9,7 @@ except ImportError:  # pragma: no cover
 
 from .base import Transport
 from ..exceptions import SessionIsClosed
-from ..protocol import STATE_CLOSED, FRAME_CLOSE
+from ..protocol import STATE_CLOSED, FRAME_CLOSE, FRAME_HEARTBEAT
 from ..protocol import loads, close_frame
 
 
@@ -28,6 +28,8 @@ class WebSocketTransport(Transport):
                     await ws.close()
                 finally:
                     await session._remote_closed()
+            elif frame == FRAME_HEARTBEAT:
+                session._tick()
 
     async def client(self, ws, session):
         while True:

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -26,7 +26,7 @@ class TestSession:
 
         assert session.id == 'id'
         assert not session.expired
-        assert session.expires == now + timedelta(seconds=10)
+        assert session.expires == now + timedelta(seconds=40)
 
         assert session._hits == 0
         assert session._heartbeats == 0


### PR DESCRIPTION
As novoxudonoser  says  [here](https://github.com/aio-libs/sockjs/pull/226)  sockjs websocket transport fail and close session.

There are 2 steps to correct this (IMHO):

1. Change timeout to 40s, above heartbeat value (25 are fine).
2. Run session._tick() when send FRAME_HEARTBEAT to set the new expire time.

Thanks.
