### PR TITLE
tick after dequeue so heartbeat keeps session live

### DIFF
--- a/sockjs/session.py
+++ b/sockjs/session.py
@@ -142,6 +142,7 @@ class Session(object):
 
         if self._queue:
             frame, payload = self._queue.popleft()
+            self._tick()
             if pack:
                 if frame == FRAME_CLOSE:
                     return FRAME_CLOSE, close_frame(*payload)


### PR DESCRIPTION
## What do these changes do?

Prolong the live of the session every time a message is dequeued, including after heartbeat.

## Are there changes in behavior for the user?

The session will not always die "timeout" time after creation.

## Related issue number

https://github.com/aio-libs/sockjs/issues/38

