### PR TITLE
Web socket transport fix

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,6 +2,7 @@
 CHANGES
 =======
 
+- Set WebSocketTransport to ignore empty frames and added the ability to process multi messages (383.feature).
 
 0.10.0 (2019-10-20)
 -------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,4 @@ pytest-sugar==0.9.4
 pytest-mock==3.3.1
 sphinx==3.2.1
 aiohttp==3.6.3
-yarl==1.6.0
-multidict==5.0.0
 -e .

--- a/sockjs/transports/websocket.py
+++ b/sockjs/transports/websocket.py
@@ -36,9 +36,6 @@ class WebSocketTransport(Transport):
                 if not data:
                     continue
 
-                if data.startswith("["):
-                    data = data[1:-1]
-
                 try:
                     text = loads(data)
                 except Exception as exc:
@@ -47,7 +44,10 @@ class WebSocketTransport(Transport):
                     await ws.close(message=b"broken json")
                     break
 
-                await session._remote_message(text)
+                if data.startswith("["):
+                    await session._remote_messages(text)
+                else:
+                    await session._remote_message(text)
 
             elif msg.type == web.WSMsgType.close:
                 await session._remote_close()

--- a/tests/test_transport_websocket.py
+++ b/tests/test_transport_websocket.py
@@ -114,6 +114,6 @@ async def test_frames(make_transport, make_handler):
     session = transp.session
     await transp.client(ws, session)
 
-    assert result[0][0].data == 'single_msg'
-    assert result[1][0].data == 'msg1'
-    assert result[2][0].data == 'msg2'
+    assert result[0][0].data == "single_msg"
+    assert result[1][0].data == "msg1"
+    assert result[2][0].data == "msg2"

--- a/tests/test_transport_websocket.py
+++ b/tests/test_transport_websocket.py
@@ -1,6 +1,8 @@
 import asyncio
+from asyncio import Future
+from unittest import mock
 
-from aiohttp import web
+from aiohttp import web, WSMessage, WSMsgType
 
 import pytest
 
@@ -13,8 +15,8 @@ from sockjs.transports import WebSocketTransport
 
 @pytest.fixture
 def make_transport(make_manager, make_request, make_handler, make_fut):
-    def maker(method="GET", path="/", query_params={}):
-        handler = make_handler(None)
+    def maker(method="GET", path="/", query_params={}, handler=None):
+        handler = handler or make_handler(None)
         manager = make_manager(handler)
         request = make_request(method, path, query_params=query_params)
         request.app.freeze()
@@ -74,3 +76,34 @@ async def test_server_close(app, make_manager, make_request):
 async def test_session_has_request(make_transport, make_fut):
     transp = make_transport(method="POST")
     assert isinstance(transp.session.request, web.Request)
+
+
+async def test_frames(make_transport, make_handler):
+    result = []
+    handler = make_handler(result)
+    transp = make_transport(handler=handler)
+
+    empty_message = Future()
+    empty_message.set_result(WSMessage(type=WSMsgType.text, data="", extra=""))
+
+    empty_frame = Future()
+    empty_frame.set_result(WSMessage(type=WSMsgType.text, data="[]", extra=""))
+
+    single_msg_frame = Future()
+    single_msg_frame.set_result(WSMessage(type=WSMsgType.text, data='"single_msg"', extra=""))
+
+    multi_msg_frame = Future()
+    multi_msg_frame.set_result(WSMessage(type=WSMsgType.text, data='["msg1", "msg2"]', extra=""))
+
+    close_frame = Future()
+    close_frame.set_result(WSMessage(type=WSMsgType.closed, data="", extra=""))
+
+    ws = mock.Mock()
+    ws.receive.side_effect = [empty_message, empty_frame, single_msg_frame, multi_msg_frame, close_frame]
+
+    session = transp.session
+    await transp.client(ws, session)
+
+    assert result[0][0].data == 'single_msg'
+    assert result[1][0].data == 'msg1'
+    assert result[2][0].data == 'msg2'

--- a/tests/test_transport_websocket.py
+++ b/tests/test_transport_websocket.py
@@ -90,16 +90,26 @@ async def test_frames(make_transport, make_handler):
     empty_frame.set_result(WSMessage(type=WSMsgType.text, data="[]", extra=""))
 
     single_msg_frame = Future()
-    single_msg_frame.set_result(WSMessage(type=WSMsgType.text, data='"single_msg"', extra=""))
+    single_msg_frame.set_result(
+        WSMessage(type=WSMsgType.text, data='"single_msg"', extra="")
+    )
 
     multi_msg_frame = Future()
-    multi_msg_frame.set_result(WSMessage(type=WSMsgType.text, data='["msg1", "msg2"]', extra=""))
+    multi_msg_frame.set_result(
+        WSMessage(type=WSMsgType.text, data='["msg1", "msg2"]', extra="")
+    )
 
     close_frame = Future()
     close_frame.set_result(WSMessage(type=WSMsgType.closed, data="", extra=""))
 
     ws = mock.Mock()
-    ws.receive.side_effect = [empty_message, empty_frame, single_msg_frame, multi_msg_frame, close_frame]
+    ws.receive.side_effect = [
+        empty_message,
+        empty_frame,
+        single_msg_frame,
+        multi_msg_frame,
+        close_frame,
+    ]
 
     session = transp.session
     await transp.client(ws, session)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
Set WebSocketTransport to ignore empty frames and added the ability to process multi messages from clients.

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->
The server will not decode json messages in frames anymore. 
`'["{\"foo\": 123}"]'  => "{\"foo\": 123}"` 

Added ability to process multi messages in a single frame from the client:
`'["msg1", "msg2"]'` 

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
