### PR TITLE
Bump to 0.11.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,12 +2,13 @@
 CHANGES
 =======
 
-0.11.0 (unreleased)
+0.11.0 (2020-10-22)
 -------------------
 
 - **Breaking change:** Added into the WebSocketTransport the ability
   to process multi messages from client (#383).
-- Set WebSocketTransport to ignore empty frames (#383).
+- Added into WebSocketTransport ignoring of empty frames received
+  from client. (#383).
 - Added tick after dequeue so heartbeat keeps session live (#265).
 - Fix race condition during iteration over sessions (#217).
 - Support Python 3.8.

--- a/examples/chat.html
+++ b/examples/chat.html
@@ -21,7 +21,7 @@
             return $(this).attr('id');
         }).get();
 
-        conn = new SockJS('http://' + window.location.host + '/sockjs/', transports, {debug: true});
+        conn = new SockJS('http://' + window.location.host + '/sockjs/', [], {debug: true, transports: transports});
 
         log('Connecting...');
 

--- a/sockjs/__init__.py
+++ b/sockjs/__init__.py
@@ -20,7 +20,7 @@ from sockjs.protocol import MSG_CLOSED
 from sockjs.route import get_manager, add_endpoint
 
 
-__version__ = "0.10.0"
+__version__ = "0.11.0"
 
 
 __all__ = (


### PR DESCRIPTION
- Fixed examples of using of SockJS server (#264).
- Bump to 0.11.0
