### PR TITLE
Replace async_timeout with asyncio.timeout

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,9 +31,10 @@ setup(
         "Intended Audience :: Developers",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
         "Programming Language :: Python :: Implementation :: CPython",
         "Topic :: Internet :: WWW/HTTP",
         "Framework :: AsyncIO",
@@ -43,11 +44,8 @@ setup(
     url="https://github.com/aio-libs/sockjs/",
     license="Apache 2",
     packages=find_packages(),
-    python_requires=">=3.10.0",
-    install_requires=[
-        "aiohttp>=3.7.4",
-        "async-timeout>=4.0.3",
-    ],
+    python_requires=">=3.11",
+    install_requires=[ "aiohttp>=3.7.4", ],
     extras_require={
         "test": [
             "pytest",

--- a/sockjs/transports/rawwebsocket.py
+++ b/sockjs/transports/rawwebsocket.py
@@ -6,7 +6,6 @@ from typing import Optional
 from uuid import uuid4
 
 from aiohttp import web
-from async_timeout import timeout
 
 from .base import Transport
 from .utils import cancel_tasks

--- a/sockjs/transports/utils.py
+++ b/sockjs/transports/utils.py
@@ -2,7 +2,6 @@ import asyncio
 import http.cookies
 from datetime import datetime, timedelta
 
-import async_timeout
 from aiohttp import hdrs
 
 
@@ -45,7 +44,7 @@ async def cancel_tasks(*coros_or_futures, timeout=1):
         waiting_to_complete.append(fut)
     if waiting_to_complete:
         try:
-            async with async_timeout.timeout(timeout):
+            async with asyncio.timeout(timeout):
                 await asyncio.gather(*waiting_to_complete, return_exceptions=True)
         except asyncio.TimeoutError:
             pass

--- a/sockjs/transports/websocket.py
+++ b/sockjs/transports/websocket.py
@@ -8,7 +8,6 @@ from uuid import uuid4
 
 from aiohttp import web
 from aiohttp.web_exceptions import HTTPMethodNotAllowed
-from async_timeout import timeout
 
 from .base import Transport
 from .utils import cancel_tasks


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Replace async_timeout with asyncio.timeout. This library has been upstreamed into Python 3.11+.

## Are there changes in behavior for the user?

No

## Related issue number

- https://github.com/NixOS/nixpkgs/pull/461868

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
